### PR TITLE
WINDUP-2221 Change docker image label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 hs_err_pid*
 
 target/
+*.iml
+.idea

--- a/build/change_docker_image_tag.groovy
+++ b/build/change_docker_image_tag.groovy
@@ -1,0 +1,8 @@
+import groovy.json.*
+
+def openshiftTemplate = new File(this.args[0])
+def jsonSlurper = new JsonSlurper().parseText(openshiftTemplate.text)
+def parameter = jsonSlurper.parameters.find { it.name == "DOCKER_IMAGES_TAG" }
+parameter.value = this.args[1]
+openshiftTemplate.write(new JsonBuilder(jsonSlurper).toPrettyString())
+

--- a/templates/src/main/resources/web-template-empty-dir-executor.json
+++ b/templates/src/main/resources/web-template-empty-dir-executor.json
@@ -7,7 +7,7 @@
             "iconClass": "icon-jboss",
             "tags": "eap,postgresql,javaee,java,database,jboss,xpaas",
             "version": "1.3.2",
-            "openshift.io/display-name": "Red Hat Application Migration Toolkit 4.1"
+            "openshift.io/display-name": "Red Hat Application Migration Toolkit"
         },
         "name": "rhamt-web-console"
     },
@@ -392,28 +392,28 @@
             }
         },
         {
-           "kind": "Route",
-           "apiVersion": "v1",
-           "id": "${APPLICATION_NAME}-https",
-           "metadata": {
-               "name": "secure-${APPLICATION_NAME}",
-               "labels": {
-                   "application": "${APPLICATION_NAME}"
-               },
-               "annotations": {
-                   "description": "Route for application's https service."
-               }
-           },
-           "spec": {
-               "host": "${HOSTNAME_HTTP}",
-               "to": {
-                   "name": "${APPLICATION_NAME}"
-               },
-               "tls": {
-                   "termination": "edge"
-               }
-           }
-       },
+            "kind": "Route",
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-https",
+            "metadata": {
+                "name": "secure-${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "Route for application's https service."
+                }
+            },
+            "spec": {
+                "host": "${HOSTNAME_HTTP}",
+                "to": {
+                    "name": "${APPLICATION_NAME}"
+                },
+                "tls": {
+                    "termination": "edge"
+                }
+            }
+        },
         {
             "kind": "DeploymentConfig",
             "apiVersion": "v1",
@@ -428,11 +428,10 @@
                     "type": "Recreate"
                 },
                 "triggers": [
-
-                   {
-                       "type": "ConfigChange"
-                   }
-               ],
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
                 "replicas": 1,
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
@@ -729,11 +728,10 @@
                     "type": "Recreate"
                 },
                 "triggers": [
-
-                   {
-                       "type": "ConfigChange"
-                   }
-               ],
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
                 "replicas": 1,
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}-executor"
@@ -798,6 +796,7 @@
                                     }
                                 },
                                 "ports": [
+                                    
                                 ],
                                 "env": [
                                     {
@@ -826,7 +825,9 @@
                         "volumes": [
                             {
                                 "name": "${APPLICATION_NAME}-rhamt-web-executor-volume",
-                                "emptyDir": {}
+                                "emptyDir": {
+                                    
+                                }
                             }
                         ]
                     }

--- a/templates/src/main/resources/web-template.json
+++ b/templates/src/main/resources/web-template.json
@@ -7,7 +7,7 @@
             "iconClass": "icon-jboss",
             "tags": "eap,postgresql,javaee,java,database,jboss,xpaas",
             "version": "1.3.2",
-            "openshift.io/display-name": "Red Hat Application Migration Toolkit 4.1"
+            "openshift.io/display-name": "Red Hat Application Migration Toolkit"
         },
         "name": "rhamt-web-console"
     },
@@ -392,28 +392,28 @@
             }
         },
         {
-           "kind": "Route",
-           "apiVersion": "v1",
-           "id": "${APPLICATION_NAME}-https",
-           "metadata": {
-               "name": "secure-${APPLICATION_NAME}",
-               "labels": {
-                   "application": "${APPLICATION_NAME}"
-               },
-               "annotations": {
-                   "description": "Route for application's https service."
-               }
-           },
-           "spec": {
-               "host": "${HOSTNAME_HTTP}",
-               "to": {
-                   "name": "${APPLICATION_NAME}"
-               },
-               "tls": {
-                   "termination": "edge"
-               }
-           }
-       },
+            "kind": "Route",
+            "apiVersion": "v1",
+            "id": "${APPLICATION_NAME}-https",
+            "metadata": {
+                "name": "secure-${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "description": "Route for application's https service."
+                }
+            },
+            "spec": {
+                "host": "${HOSTNAME_HTTP}",
+                "to": {
+                    "name": "${APPLICATION_NAME}"
+                },
+                "tls": {
+                    "termination": "edge"
+                }
+            }
+        },
         {
             "kind": "DeploymentConfig",
             "apiVersion": "v1",
@@ -428,11 +428,10 @@
                     "type": "Recreate"
                 },
                 "triggers": [
-
-                   {
-                       "type": "ConfigChange"
-                   }
-               ],
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
                 "replicas": 1,
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}"
@@ -729,11 +728,10 @@
                     "type": "Recreate"
                 },
                 "triggers": [
-
-                   {
-                       "type": "ConfigChange"
-                   }
-               ],
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
                 "replicas": 1,
                 "selector": {
                     "deploymentConfig": "${APPLICATION_NAME}-executor"
@@ -798,6 +796,7 @@
                                     }
                                 },
                                 "ports": [
+                                    
                                 ],
                                 "env": [
                                     {


### PR DESCRIPTION
Script to be used during the release build in CI to safely change the docker image's tag from `latest` to the right release version.
The templates have been committed as well so that, when the script runs, the only different will be the tag value.