### PR TITLE
WINDUP-2258 Enhanced and added templates to work with NFS shared storage

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -34,6 +34,7 @@
                 <configuration>
                     <mode>kubernetes</mode>
                     <buildStrategy>docker</buildStrategy>
+                    <autoPull>always</autoPull>
                     <images>
                         <image>
                             <name>${docker.name.windup.cli}</name>

--- a/messaging-executor/pom.xml
+++ b/messaging-executor/pom.xml
@@ -33,6 +33,7 @@
                 <configuration>
                     <mode>kubernetes</mode>
                     <buildStrategy>docker</buildStrategy>
+                    <autoPull>always</autoPull>
                     <images>
                         <image>
                             <name>${docker.name.windup.web.executor}</name>

--- a/templates/src/main/resources/deprecated/web-template.json
+++ b/templates/src/main/resources/deprecated/web-template.json
@@ -349,6 +349,13 @@
             "name": "DOCKER_IMAGES_TAG",
             "value": "latest",
             "required": true
+        },
+        {
+            "displayName": "Undertow max post size",
+            "description": "The maximum value of the size the an HTTP post request",
+            "name": "MAX_POST_SIZE",
+            "value": "4294967296",
+            "required": true
         }
     ],
     "objects": [
@@ -705,6 +712,14 @@
                                     {
                                         "name": "SSO_TRUSTSTORE_PASSWORD",
                                         "value": "${SSO_TRUSTSTORE_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "GC_MAX_METASPACE_SIZE",
+                                        "value": "512"
+                                    },
+                                    {
+                                        "name": "MAX_POST_SIZE",
+                                        "value": "${MAX_POST_SIZE}"
                                     }
                                 ]
                             }

--- a/templates/src/main/resources/web-template-empty-dir-executor-shared-storage.json
+++ b/templates/src/main/resources/web-template-empty-dir-executor-shared-storage.json
@@ -43,7 +43,7 @@
             "displayName": "Serialization Method",
             "description": "The value determines the approach used for transferring data between the UI components and the analysis engine.",
             "name": "MESSAGING_SERIALIZER",
-            "value": "http.post.serializer",
+            "value": "shared.storage",
             "required": true
         },
         {
@@ -345,7 +345,7 @@
         },
         {
             "displayName": "Docker Images Tag",
-            "description": "The value of the tag for the Docker imgaes to be used",
+            "description": "The value of the tag for the Docker images to be used",
             "name": "DOCKER_IMAGES_TAG",
             "value": "latest",
             "required": true
@@ -471,6 +471,11 @@
                                 "volumeMounts": [
                                     {
                                         "name": "${APPLICATION_NAME}-rhamt-web-pvol",
+                                        "mountPath": "/opt/eap/standalone/data/windup",
+                                        "readOnly": false
+                                    },
+                                    {
+                                        "name": "${APPLICATION_NAME}-rhamt-web-pvol-data",
                                         "mountPath": "/opt/eap/standalone/data",
                                         "readOnly": false
                                     }
@@ -529,6 +534,10 @@
                                     {
                                         "name": "MESSAGING_SERIALIZER",
                                         "value": "${MESSAGING_SERIALIZER}"
+                                    },
+                                    {
+                                        "name": "GRAPH_BASE_OUTPUT_PATH",
+                                        "value": "/opt/eap/standalone/data/windup-graphs"
                                     },
                                     {
                                         "name": "DB_SERVICE_PREFIX_MAPPING",
@@ -715,6 +724,12 @@
                                 "persistentVolumeClaim": {
                                     "claimName": "${APPLICATION_NAME}-rhamt-web-claim"
                                 }
+                            },
+                            {
+                                "name": "${APPLICATION_NAME}-rhamt-web-pvol-data",
+                                "emptyDir": {
+
+                                }
                             }
                         ]
                     }
@@ -771,6 +786,11 @@
                                 "volumeMounts": [
                                     {
                                         "name": "${APPLICATION_NAME}-rhamt-web-pvol",
+                                        "mountPath": "/opt/eap/standalone/data/windup",
+                                        "readOnly": false
+                                    },
+                                    {
+                                        "name": "${APPLICATION_NAME}-rhamt-web-executor-volume",
                                         "mountPath": "/opt/eap/standalone/data",
                                         "readOnly": false
                                     }
@@ -811,6 +831,10 @@
                                         "value": "false"
                                     },
                                     {
+                                        "name": "GRAPH_BASE_OUTPUT_PATH",
+                                        "value": "/opt/eap/standalone/data/windup-graphs"
+                                    },
+                                    {
                                         "name": "MESSAGING_SERIALIZER",
                                         "value": "${MESSAGING_SERIALIZER}"
                                     },
@@ -833,7 +857,13 @@
                             {
                                 "name": "${APPLICATION_NAME}-rhamt-web-pvol",
                                 "persistentVolumeClaim": {
-                                    "claimName": "${APPLICATION_NAME}-rhamt-web-executor-claim"
+                                    "claimName": "${APPLICATION_NAME}-rhamt-web-claim"
+                                }
+                            },
+                            {
+                                "name": "${APPLICATION_NAME}-rhamt-web-executor-volume",
+                                "emptyDir": {
+
                                 }
                             }
                         ]
@@ -1023,27 +1053,7 @@
             },
             "spec": {
                 "accessModes": [
-                    "ReadWriteOnce"
-                ],
-                "resources": {
-                    "requests": {
-                        "storage": "${VOLUME_CAPACITY}"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "v1",
-            "kind": "PersistentVolumeClaim",
-            "metadata": {
-                "name": "${APPLICATION_NAME}-rhamt-web-executor-claim",
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                }
-            },
-            "spec": {
-                "accessModes": [
-                    "ReadWriteOnce"
+                    "ReadWriteMany"
                 ],
                 "resources": {
                     "requests": {

--- a/templates/src/main/resources/web-template-empty-dir-executor-shared-storage.json
+++ b/templates/src/main/resources/web-template-empty-dir-executor-shared-storage.json
@@ -349,6 +349,13 @@
             "name": "DOCKER_IMAGES_TAG",
             "value": "latest",
             "required": true
+        },
+        {
+            "displayName": "Undertow max post size",
+            "description": "The maximum value of the size the an HTTP post request",
+            "name": "MAX_POST_SIZE",
+            "value": "10485760",
+            "required": true
         }
     ],
     "objects": [
@@ -714,6 +721,14 @@
                                     {
                                         "name": "SSO_TRUSTSTORE_PASSWORD",
                                         "value": "${SSO_TRUSTSTORE_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "GC_MAX_METASPACE_SIZE",
+                                        "value": "512"
+                                    },
+                                    {
+                                        "name": "MAX_POST_SIZE",
+                                        "value": "${MAX_POST_SIZE}"
                                     }
                                 ]
                             }

--- a/templates/src/main/resources/web-template-empty-dir-executor-shared-storage.json
+++ b/templates/src/main/resources/web-template-empty-dir-executor-shared-storage.json
@@ -26,24 +26,44 @@
             "required": true
         },
         {
-            "displayName": "Requested CPU",
-            "description": "The number of CPU cores to request.",
-            "name": "REQUESTED_CPU",
+            "displayName": "Web Console Requested CPU",
+            "description": "The number of CPU cores to request for the Web Console.",
+            "name": "WEB_CONSOLE_REQUESTED_CPU",
             "value": "2",
             "required": true
         },
         {
-            "displayName": "Requested Memory",
-            "description": "The amount of memory to request (eg, 4Gi).",
-            "name": "REQUESTED_MEMORY",
+            "displayName": "Web Console Requested Memory",
+            "description": "The amount of memory to request (eg, 4Gi) for the Web Console.",
+            "name": "WEB_CONSOLE_REQUESTED_MEMORY",
             "value": "4Gi",
             "required": true
         },
         {
-            "displayName": "Serialization Method",
+            "displayName": "Executor Requested CPU",
+            "description": "The number of CPU cores to request for the Executor.",
+            "name": "EXECUTOR_REQUESTED_CPU",
+            "value": "2",
+            "required": true
+        },
+        {
+            "displayName": "Executor Requested Memory",
+            "description": "The amount of memory to request (eg, 4Gi) for the Executor.",
+            "name": "EXECUTOR_REQUESTED_MEMORY",
+            "value": "4Gi",
+            "required": true
+        },
+        {"displayName": "Serialization Method",
             "description": "The value determines the approach used for transferring data between the UI components and the analysis engine.",
             "name": "MESSAGING_SERIALIZER",
             "value": "shared.storage",
+            "required": true
+        },
+        {
+            "displayName": "RHAMT Volume Capacity",
+            "description": "Size of persistent storage for RHAMT volume.",
+            "name": "RHAMT_VOLUME_CAPACITY",
+            "value": "20G",
             "required": true
         },
         {
@@ -354,7 +374,7 @@
             "displayName": "Undertow max post size",
             "description": "The maximum value of the size the an HTTP post request",
             "name": "MAX_POST_SIZE",
-            "value": "10485760",
+            "value": "1073741824",
             "required": true
         }
     ],
@@ -467,12 +487,12 @@
                                 "imagePullPolicy": "Always",
                                 "resources": {
                                     "requests": {
-                                        "cpu": "${REQUESTED_CPU}",
-                                        "memory": "${REQUESTED_MEMORY}"
+                                        "cpu": "${WEB_CONSOLE_REQUESTED_CPU}",
+                                        "memory": "${WEB_CONSOLE_REQUESTED_MEMORY}"
                                     },
                                     "limits": {
-                                        "cpu": "${REQUESTED_CPU}",
-                                        "memory": "${REQUESTED_MEMORY}"
+                                        "cpu": "${WEB_CONSOLE_REQUESTED_CPU}",
+                                        "memory": "${WEB_CONSOLE_REQUESTED_MEMORY}"
                                     }
                                 },
                                 "volumeMounts": [
@@ -790,12 +810,12 @@
                                 "imagePullPolicy": "Always",
                                 "resources": {
                                     "requests": {
-                                        "cpu": "${REQUESTED_CPU}",
-                                        "memory": "${REQUESTED_MEMORY}"
+                                        "cpu": "${EXECUTOR_REQUESTED_CPU}",
+                                        "memory": "${EXECUTOR_REQUESTED_MEMORY}"
                                     },
                                     "limits": {
-                                        "cpu": "${REQUESTED_CPU}",
-                                        "memory": "${REQUESTED_MEMORY}"
+                                        "cpu": "${EXECUTOR_REQUESTED_CPU}",
+                                        "memory": "${EXECUTOR_REQUESTED_MEMORY}"
                                     }
                                 },
                                 "volumeMounts": [
@@ -1072,7 +1092,7 @@
                 ],
                 "resources": {
                     "requests": {
-                        "storage": "${VOLUME_CAPACITY}"
+                        "storage": "${RHAMT_VOLUME_CAPACITY}"
                     }
                 }
             }

--- a/templates/src/main/resources/web-template-empty-dir-executor.json
+++ b/templates/src/main/resources/web-template-empty-dir-executor.json
@@ -349,6 +349,13 @@
             "name": "DOCKER_IMAGES_TAG",
             "value": "latest",
             "required": true
+        },
+        {
+            "displayName": "Undertow max post size",
+            "description": "The maximum value of the size the an HTTP post request",
+            "name": "MAX_POST_SIZE",
+            "value": "4294967296",
+            "required": true
         }
     ],
     "objects": [
@@ -710,6 +717,14 @@
                                     {
                                         "name": "SSO_TRUSTSTORE_PASSWORD",
                                         "value": "${SSO_TRUSTSTORE_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "GC_MAX_METASPACE_SIZE",
+                                        "value": "512"
+                                    },
+                                    {
+                                        "name": "MAX_POST_SIZE",
+                                        "value": "${MAX_POST_SIZE}"
                                     }
                                 ]
                             }

--- a/templates/src/main/resources/web-template-empty-dir-executor.json
+++ b/templates/src/main/resources/web-template-empty-dir-executor.json
@@ -337,6 +337,13 @@
             "required": false
         },
         {
+            "displayName": "Docker Images User ID",
+            "description": "The value of the user name for the Docker images to be used",
+            "name": "DOCKER_IMAGES_USER",
+            "value": "windup3",
+            "required": true
+        },
+        {
             "displayName": "Docker Images Tag",
             "description": "The value of the tag for the Docker imgaes to be used",
             "name": "DOCKER_IMAGES_TAG",
@@ -449,7 +456,7 @@
                         "containers": [
                             {
                                 "name": "${APPLICATION_NAME}",
-                                "image": "docker.io/windup3/windup-web-openshift:${DOCKER_IMAGES_TAG}",
+                                "image": "docker.io/${DOCKER_IMAGES_USER}/windup-web-openshift:${DOCKER_IMAGES_TAG}",
                                 "imagePullPolicy": "Always",
                                 "resources": {
                                     "requests": {
@@ -464,6 +471,11 @@
                                 "volumeMounts": [
                                     {
                                         "name": "${APPLICATION_NAME}-rhamt-web-pvol",
+                                        "mountPath": "/opt/eap/standalone/data/windup",
+                                        "readOnly": false
+                                    },
+                                    {
+                                        "name": "${APPLICATION_NAME}-rhamt-web-pvol-data",
                                         "mountPath": "/opt/eap/standalone/data",
                                         "readOnly": false
                                     }
@@ -708,6 +720,12 @@
                                 "persistentVolumeClaim": {
                                     "claimName": "${APPLICATION_NAME}-rhamt-web-claim"
                                 }
+                            },
+                            {
+                                "name": "${APPLICATION_NAME}-rhamt-web-pvol-data",
+                                "emptyDir": {
+
+                                }
                             }
                         ]
                     }
@@ -749,7 +767,7 @@
                         "containers": [
                             {
                                 "name": "${APPLICATION_NAME}-executor",
-                                "image": "docker.io/windup3/windup-web-openshift-messaging-executor:${DOCKER_IMAGES_TAG}",
+                                "image": "docker.io/${DOCKER_IMAGES_USER}/windup-web-openshift-messaging-executor:${DOCKER_IMAGES_TAG}",
                                 "imagePullPolicy": "Always",
                                 "resources": {
                                     "requests": {

--- a/templates/src/main/resources/web-template-empty-dir-executor.json
+++ b/templates/src/main/resources/web-template-empty-dir-executor.json
@@ -26,16 +26,30 @@
             "required": true
         },
         {
-            "displayName": "Requested CPU",
-            "description": "The number of CPU cores to request.",
-            "name": "REQUESTED_CPU",
+            "displayName": "Web Console Requested CPU",
+            "description": "The number of CPU cores to request for the Web Console.",
+            "name": "WEB_CONSOLE_REQUESTED_CPU",
             "value": "2",
             "required": true
         },
         {
-            "displayName": "Requested Memory",
-            "description": "The amount of memory to request (eg, 4Gi).",
-            "name": "REQUESTED_MEMORY",
+            "displayName": "Web Console Requested Memory",
+            "description": "The amount of memory to request (eg, 4Gi) for the Web Console.",
+            "name": "WEB_CONSOLE_REQUESTED_MEMORY",
+            "value": "4Gi",
+            "required": true
+        },
+        {
+            "displayName": "Executor Requested CPU",
+            "description": "The number of CPU cores to request for the Executor.",
+            "name": "EXECUTOR_REQUESTED_CPU",
+            "value": "2",
+            "required": true
+        },
+        {
+            "displayName": "Executor Requested Memory",
+            "description": "The amount of memory to request (eg, 4Gi) for the Executor.",
+            "name": "EXECUTOR_REQUESTED_MEMORY",
             "value": "4Gi",
             "required": true
         },
@@ -44,6 +58,13 @@
             "description": "The value determines the approach used for transferring data between the UI components and the analysis engine.",
             "name": "MESSAGING_SERIALIZER",
             "value": "http.post.serializer",
+            "required": true
+        },
+        {
+            "displayName": "RHAMT Volume Capacity",
+            "description": "Size of persistent storage for RHAMT volume.",
+            "name": "RHAMT_VOLUME_CAPACITY",
+            "value": "20G",
             "required": true
         },
         {
@@ -467,12 +488,12 @@
                                 "imagePullPolicy": "Always",
                                 "resources": {
                                     "requests": {
-                                        "cpu": "${REQUESTED_CPU}",
-                                        "memory": "${REQUESTED_MEMORY}"
+                                        "cpu": "${WEB_CONSOLE_REQUESTED_CPU}",
+                                        "memory": "${WEB_CONSOLE_REQUESTED_MEMORY}"
                                     },
                                     "limits": {
-                                        "cpu": "${REQUESTED_CPU}",
-                                        "memory": "${REQUESTED_MEMORY}"
+                                        "cpu": "${WEB_CONSOLE_REQUESTED_CPU}",
+                                        "memory": "${WEB_CONSOLE_REQUESTED_MEMORY}"
                                     }
                                 },
                                 "volumeMounts": [
@@ -786,12 +807,12 @@
                                 "imagePullPolicy": "Always",
                                 "resources": {
                                     "requests": {
-                                        "cpu": "${REQUESTED_CPU}",
-                                        "memory": "${REQUESTED_MEMORY}"
+                                        "cpu": "${EXECUTOR_REQUESTED_CPU}",
+                                        "memory": "${EXECUTOR_REQUESTED_MEMORY}"
                                     },
                                     "limits": {
-                                        "cpu": "${REQUESTED_CPU}",
-                                        "memory": "${REQUESTED_MEMORY}"
+                                        "cpu": "${EXECUTOR_REQUESTED_CPU}",
+                                        "memory": "${EXECUTOR_REQUESTED_MEMORY}"
                                     }
                                 },
                                 "volumeMounts": [
@@ -1053,7 +1074,7 @@
                 ],
                 "resources": {
                     "requests": {
-                        "storage": "${VOLUME_CAPACITY}"
+                        "storage": "${RHAMT_VOLUME_CAPACITY}"
                     }
                 }
             }

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -33,6 +33,7 @@
                 <configuration>
                     <mode>kubernetes</mode>
                     <buildStrategy>docker</buildStrategy>
+                    <autoPull>always</autoPull>
                     <images>
                         <image>
                             <name>${docker.name.windup.web}</name>

--- a/web/src/main/resources/cli/setup.cli
+++ b/web/src/main/resources/cli/setup.cli
@@ -22,7 +22,7 @@ jms-topic add --topic-address=executorCancellation --entries=[topics/executorCan
 /subsystem=keycloak/secure-deployment=api.war:add(realm=rhamt, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=rhamt-web, public-client=true)
 /subsystem=keycloak/secure-deployment=rhamt-web.war:add(realm=rhamt, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=rhamt-web, public-client=true)
 
-/subsystem=undertow/server=default-server/http-listener=default:write-attribute(name=max-post-size, value=943718400)
+/subsystem=undertow/server=default-server/http-listener=default:write-attribute(name=max-post-size, value="${env.MAX_POST_SIZE}")
 
 /subsystem=undertow/configuration=handler/file=root-redirect:add(path=${jboss.home.dir}/root-redirect)
 /subsystem=undertow/server=default-server/host=default-host/location=\//:write-attribute(name=handler,value=root-redirect)

--- a/web/src/main/resources/scripts/webapp-launch.sh
+++ b/web/src/main/resources/scripts/webapp-launch.sh
@@ -7,6 +7,7 @@ cd $DIR
 sed -i -e 's#-Xbootclasspath/p:${JBOSS_MODULES_JAR}:${JBOSS_LOGMANAGER_JAR}:${JBOSS_LOGMANAGER_EXT_JAR}##g' /opt/eap/bin/standalone.conf
 sed -i -e 's#-Djava.util.logging.manager=org.jboss.logmanager.LogManager##g' /opt/eap/bin/standalone.conf
 sed -i -e 's#-javaagent:$JBOSS_HOME/jolokia.jar=port=8778,protocol=https,caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt,clientPrincipal=cn=system:master-proxy,useSslClientAuthentication=true,extraClientCheck=true,host=0.0.0.0,discoveryEnabled=false##g' /opt/eap/bin/standalone.conf
+sed -i -e 's#MaxMetaspaceSize=256m#MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=512m#g' /opt/eap/bin/standalone.conf
 
 # Remove the jboss logging package from system packages
 sed -i -e 's#JBOSS_MODULES_SYSTEM_PKGS="org.jboss.logmanager,jdk.nashorn.api"##g' /opt/eap/bin/launch/jboss_modules_system_pkgs.sh


### PR DESCRIPTION
Depends on https://github.com/windup/windup-web/pull/595 and https://github.com/windup/windup/pull/1342

- introduced `DOCKER_IMAGES_USER` env variable so that when someone has to test using a different image, the username can be changed in just one place
- now only `/opt/eap/standalone/data/windup` will be mounted on a PV while `/opt/eap/standalone/data` will be based on `emptyDir`: this is due to the fact that H2 DB for Keycloak (stored in `/opt/eap/standalone/data`) can not work on an NFS based PV
- new `web-template-empty-dir-executor-shared-storage.json` template to use the already existing `web-template-empty-dir-executor.json` template within a shared storage architecture