### PR TITLE
WINDUP-2655 forced the version of EAP OCP image

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -37,7 +37,7 @@
                         <image>
                             <name>${docker.name.windup.web}</name>
                             <build>
-                                <from>registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7</from>
+                                <from>registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.0-13</from>
                                 <cmd>/opt/eap/bin/webapp-launch.sh</cmd>
                                 <assembly>
                                     <targetDir>/</targetDir>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2655
Fixed the version of the EAP 7.3 OCP image to avoid issues on changes incorporated to the image.