### PR TITLE
Set the secure-deployments to not validate the truststore 

### DIFF
--- a/web/src/main/resources/cli/secure-deployments.cli
+++ b/web/src/main/resources/cli/secure-deployments.cli
@@ -1,7 +1,7 @@
 embed-server --std-out=echo --admin-only=true --server-config=standalone-openshift.xml
 
-/subsystem=keycloak/secure-deployment=mta-web.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true)
-/subsystem=keycloak/secure-deployment=mta-ui.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true)
-/subsystem=keycloak/secure-deployment=api.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true)
+/subsystem=keycloak/secure-deployment=mta-web.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true, disable-trust-manager="${env.SSO_DISABLE_SSL_CERTIFICATE_VALIDATION}")
+/subsystem=keycloak/secure-deployment=mta-ui.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true, disable-trust-manager="${env.SSO_DISABLE_SSL_CERTIFICATE_VALIDATION}")
+/subsystem=keycloak/secure-deployment=api.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true, disable-trust-manager="${env.SSO_DISABLE_SSL_CERTIFICATE_VALIDATION}")
 
 stop-embedded-server


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2333
to avoid the issue opening the reports on https, we are disabling the validation of the certificate on Keycloak

Reusing the existing env var : SSO_DISABLE_SSL_CERTIFICATE_VALIDATION to modify the behaviour on Keycloak.