### PR TITLE
'podman' profile activation for Unix/Linux OS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
             <file>
               <missing>/var/run/docker.sock</missing>
             </file>
+            <os>
+                <name>linux</name>
+                <family>unix</family>
+            </os>
           </activation>
           <build>
             <plugins>


### PR DESCRIPTION
Implemented suggestion https://github.com/windup/windup-openshift/pull/39#issuecomment-996566904 from @carlosthe19916 

To evaluate your OS family and name, execute `mvn enforcer:display-info`