### PR TITLE
[WINDUP-3269] - JDK11 upgrade - windup-openshift project

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -38,7 +38,7 @@
                         <image>
                             <name>${docker.name.windup.cli}</name>
                             <build>
-                                <from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.8</from>
+                                <from>registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.11</from>
                                 <cmd>/opt/migrationtoolkit/bin/mta-cli</cmd>
                                 <assembly>
                                     <targetDir>/</targetDir>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -38,7 +38,7 @@
                         <image>
                             <name>${docker.name.windup.cli}</name>
                             <build>
-                                <from>registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.11</from>
+                                <from>registry.access.redhat.com/ubi8/openjdk-11:1.11</from>
                                 <cmd>/opt/migrationtoolkit/bin/mta-cli</cmd>
                                 <assembly>
                                     <targetDir>/</targetDir>

--- a/messaging-executor/pom.xml
+++ b/messaging-executor/pom.xml
@@ -37,7 +37,7 @@
                         <image>
                             <name>${docker.name.windup.web.executor}</name>
                             <build>
-                                <from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.8</from>
+                                <from>registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.11</from>
                                 <cmd>/opt/mta-cli/bin/openshift-launch.sh</cmd>
                                 <assembly>
                                     <targetDir>/</targetDir>

--- a/messaging-executor/pom.xml
+++ b/messaging-executor/pom.xml
@@ -37,7 +37,7 @@
                         <image>
                             <name>${docker.name.windup.web.executor}</name>
                             <build>
-                                <from>registry.access.redhat.com/openjdk/openjdk-11-rhel7:1.11</from>
+                                <from>registry.access.redhat.com/ubi8/openjdk-11:1.11</from>
                                 <cmd>/opt/mta-cli/bin/openshift-launch.sh</cmd>
                                 <assembly>
                                     <targetDir>/</targetDir>

--- a/messaging-executor/src/main/resources/bin/mta-cli
+++ b/messaging-executor/src/main/resources/bin/mta-cli
@@ -27,15 +27,10 @@
 ADDONS_DIR=()
 MTA_DEBUG_ARGS=()
 QUOTED_ARGS=()
-RUN_OPENREWRITE=()
-TRANSFORM_PROJECT_PATH=()
-OPENREWRITE_QUOTED_ARGS=()
-OPENREWRITE_GOAL=( "dryRun" )
 
 ## Increase the open file limit if low, to what we need or at least to the hard limit.
 ## Complain if the hard limit is lower than what we need.
-## Value set to 10000 to be aligned with windup-web-distribution
-WE_NEED=10000
+WE_NEED=1024
 MAX_HARD=$(ulimit -H -n);
 MAX_SOFT=$(ulimit -S -n);
 
@@ -43,20 +38,17 @@ if [ $MAX_SOFT == 'unlimited' ] ; then MAX_SOFT=$WE_NEED; fi;
 if [ $MAX_HARD == 'unlimited' ] ; then MAX_HARD=$WE_NEED; fi;
 
 if [ $MAX_SOFT -lt $WE_NEED ] || [ $MAX_HARD -lt $WE_NEED ]  ; then
-  if [ $MAX_HARD -lt $WE_NEED ] ; then
-    echo ""
-    echo "[WARNING] The limits ($MAX_SOFT/$MAX_HARD) for open files is too low and could make MTA unstable. Please increase them to at least $WE_NEED."
-    echo ""
-    echo "    {RHEL & Fedora} Limits are typically configured in /etc/security/limits.conf"
-    echo "     -> Follow instructions of https://access.redhat.com/solutions/60746"
-    echo ""
-    echo "    {MacOS} Limits are typically configured in /etc/launchd.conf or /etc/sysctl.conf."
-    echo "     -> Execute this script: https://gist.github.com/Maarc/d13b1e70f191d5b527a24d39dd3e2569 and restart your operating system."
-    echo ""
-  fi
-  MIN_WE_NEED_OR_CAN_HAVE=$(( $MAX_HARD > $WE_NEED ? $WE_NEED : $MAX_HARD ))
-  echo "Increasing the maximum of open files to $MIN_WE_NEED_OR_CAN_HAVE."
-  ulimit -S -n $MIN_WE_NEED_OR_CAN_HAVE
+
+  echo ""
+  echo "[WARNING] The limits ($MAX_SOFT/$MAX_HARD) for open files is too low and could make MTA unstable. Please increase them to at least $WE_NEED."
+  echo ""
+  echo "    {RHEL & Fedora} Limits are typically configured in /etc/security/limits.conf"
+  echo "     -> Follow instructions of https://access.redhat.com/solutions/60746"
+  echo ""
+  echo "    {MacOS} Limits are typically configured in /etc/launchd.conf or /etc/sysctl.conf."
+  echo "     -> Execute this script: https://gist.github.com/Maarc/d13b1e70f191d5b527a24d39dd3e2569 and restart your operating system."
+  echo ""
+
 fi
 
 
@@ -74,14 +66,10 @@ while [ -h "$PRG" ] ; do
   fi
 done
 
-saveddir=`pwd`
-
 SCRIPT_HOME=`dirname "$SCRIPT_HOME"`/..
 
 # make it fully qualified
 SCRIPT_HOME=`cd "$SCRIPT_HOME" && pwd`
-
-cd "$saveddir"
 
 echo "Changing to script home: $SCRIPT_HOME"
 cd $SCRIPT_HOME
@@ -92,22 +80,7 @@ while [ "$1" != "" ] ; do
     MTA_DEBUG_ARGS=( "-Xdebug" "-Xnoagent" "-Djava.compiler=NONE" "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000" )
   fi
 
-  if [ "$1" = "--openrewrite" ] ; then
-    RUN_OPENREWRITE=( "yes" )
-  elif [ "$1" = "--input" ] ; then
-    TRANSFORM_PROJECT_PATH=("$2")
-  elif [ "$1" = "$TRANSFORM_PROJECT_PATH" ] ; then
-    pathfound=true
-  elif [ "$1" = "--goal" ] ; then
-    OPENREWRITE_GOAL=("$2")
-  elif [ "$1" = "$OPENREWRITE_GOAL" ] ; then
-    goalfound=true
-  else
-    OPENREWRITE_QUOTED_ARGS+=("$1")
-  fi
-
   QUOTED_ARGS+=("$1")
-
   shift
 done
 
@@ -170,14 +143,10 @@ if [ -z "$MTA_HOME" ] ; then
     fi
   done
 
-  saveddir=`pwd`
-
   MTA_HOME=`dirname "$PRG"`/..
 
   # make it fully qualified
   MTA_HOME=`cd "$MTA_HOME" && pwd`
-
-  cd "$saveddir"
 fi
 
 echo Using MTA at $MTA_HOME
@@ -220,15 +189,13 @@ if [ ! -x "$JAVACMD" ] ; then
   exit 1
 fi
 
-MODULES=""
 JAVAVER=`"$JAVACMD" -version 2>&1`
 case $JAVAVER in
 *"11"*)
-    MODULES="--add-modules=java.se"
-    echo "TECH PREVIEW Running on JDK $JAVAVER"
-;;
-*1.[1-9]*)
-	echo " Error: a Java 11 or higher JRE is required to run MTA; found [$JAVACMD -version == $JAVAVER]."
+  MODULES="--add-modules=java.se"
+ ;;
+*)
+	echo " Error: a Java 11 JRE is required to run MTA; found [$JAVACMD -version == $JAVAVER]."
 	exit 1
  ;;
 esac
@@ -273,13 +240,7 @@ fi
 
 MTA_OPTS="$MTA_OPTS $FILE_DESCRIPTOR_OPTS";
 
-if [ "$RUN_OPENREWRITE" != "" ] ; then
-	( cd "$TRANSFORM_PROJECT_PATH"; exec mvn org.openrewrite.maven:rewrite-maven-plugin:4.13.0:"${OPENREWRITE_GOAL}" -DconfigLocation="${MTA_HOME}"/rules/openrewrite/rewrite.yml "${OPENREWRITE_QUOTED_ARGS[@]}" )
-	exit 0;
-
-fi
-
 JAVA_TOOL_OPTIONS=""
 
-exec "$JAVACMD" $MODULES "${MTA_DEBUG_ARGS[@]}" $MTA_OPTS -Dforge.standalone=true -Dforge.home="${MTA_HOME}" -Dwindup.home="${MTA_HOME}" \
-   -cp "${MTA_HOME}"/lib/'*' $MTA_MAIN_CLASS "${QUOTED_ARGS[@]}" "${ADDONS_DIR[@]}"
+$JAVACMD "${MTA_DEBUG_ARGS[@]}" $MTA_OPTS -Dforge.standalone=true -Dforge.home=${MTA_HOME} -Dwindup.home=${MTA_HOME} -Djboss.modules.system.pkgs=sun.reflect \
+   -cp ${MTA_HOME}/lib/'*' $MTA_MAIN_CLASS "${QUOTED_ARGS[@]}" "${ADDONS_DIR[@]}"

--- a/messaging-executor/src/main/resources/bin/mta-cli
+++ b/messaging-executor/src/main/resources/bin/mta-cli
@@ -27,10 +27,15 @@
 ADDONS_DIR=()
 MTA_DEBUG_ARGS=()
 QUOTED_ARGS=()
+RUN_OPENREWRITE=()
+TRANSFORM_PROJECT_PATH=()
+OPENREWRITE_QUOTED_ARGS=()
+OPENREWRITE_GOAL=( "dryRun" )
 
 ## Increase the open file limit if low, to what we need or at least to the hard limit.
 ## Complain if the hard limit is lower than what we need.
-WE_NEED=1024
+## Value set to 10000 to be aligned with windup-web-distribution
+WE_NEED=10000
 MAX_HARD=$(ulimit -H -n);
 MAX_SOFT=$(ulimit -S -n);
 
@@ -38,17 +43,20 @@ if [ $MAX_SOFT == 'unlimited' ] ; then MAX_SOFT=$WE_NEED; fi;
 if [ $MAX_HARD == 'unlimited' ] ; then MAX_HARD=$WE_NEED; fi;
 
 if [ $MAX_SOFT -lt $WE_NEED ] || [ $MAX_HARD -lt $WE_NEED ]  ; then
-
-  echo ""
-  echo "[WARNING] The limits ($MAX_SOFT/$MAX_HARD) for open files is too low and could make MTA unstable. Please increase them to at least $WE_NEED."
-  echo ""
-  echo "    {RHEL & Fedora} Limits are typically configured in /etc/security/limits.conf"
-  echo "     -> Follow instructions of https://access.redhat.com/solutions/60746"
-  echo ""
-  echo "    {MacOS} Limits are typically configured in /etc/launchd.conf or /etc/sysctl.conf."
-  echo "     -> Execute this script: https://gist.github.com/Maarc/d13b1e70f191d5b527a24d39dd3e2569 and restart your operating system."
-  echo ""
-
+  if [ $MAX_HARD -lt $WE_NEED ] ; then
+    echo ""
+    echo "[WARNING] The limits ($MAX_SOFT/$MAX_HARD) for open files is too low and could make MTA unstable. Please increase them to at least $WE_NEED."
+    echo ""
+    echo "    {RHEL & Fedora} Limits are typically configured in /etc/security/limits.conf"
+    echo "     -> Follow instructions of https://access.redhat.com/solutions/60746"
+    echo ""
+    echo "    {MacOS} Limits are typically configured in /etc/launchd.conf or /etc/sysctl.conf."
+    echo "     -> Execute this script: https://gist.github.com/Maarc/d13b1e70f191d5b527a24d39dd3e2569 and restart your operating system."
+    echo ""
+  fi
+  MIN_WE_NEED_OR_CAN_HAVE=$(( $MAX_HARD > $WE_NEED ? $WE_NEED : $MAX_HARD ))
+  echo "Increasing the maximum of open files to $MIN_WE_NEED_OR_CAN_HAVE."
+  ulimit -S -n $MIN_WE_NEED_OR_CAN_HAVE
 fi
 
 
@@ -66,10 +74,14 @@ while [ -h "$PRG" ] ; do
   fi
 done
 
+saveddir=`pwd`
+
 SCRIPT_HOME=`dirname "$SCRIPT_HOME"`/..
 
 # make it fully qualified
 SCRIPT_HOME=`cd "$SCRIPT_HOME" && pwd`
+
+cd "$saveddir"
 
 echo "Changing to script home: $SCRIPT_HOME"
 cd $SCRIPT_HOME
@@ -80,7 +92,22 @@ while [ "$1" != "" ] ; do
     MTA_DEBUG_ARGS=( "-Xdebug" "-Xnoagent" "-Djava.compiler=NONE" "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000" )
   fi
 
+  if [ "$1" = "--openrewrite" ] ; then
+    RUN_OPENREWRITE=( "yes" )
+  elif [ "$1" = "--input" ] ; then
+    TRANSFORM_PROJECT_PATH=("$2")
+  elif [ "$1" = "$TRANSFORM_PROJECT_PATH" ] ; then
+    pathfound=true
+  elif [ "$1" = "--goal" ] ; then
+    OPENREWRITE_GOAL=("$2")
+  elif [ "$1" = "$OPENREWRITE_GOAL" ] ; then
+    goalfound=true
+  else
+    OPENREWRITE_QUOTED_ARGS+=("$1")
+  fi
+
   QUOTED_ARGS+=("$1")
+
   shift
 done
 
@@ -143,10 +170,14 @@ if [ -z "$MTA_HOME" ] ; then
     fi
   done
 
+  saveddir=`pwd`
+
   MTA_HOME=`dirname "$PRG"`/..
 
   # make it fully qualified
   MTA_HOME=`cd "$MTA_HOME" && pwd`
+
+  cd "$saveddir"
 fi
 
 echo Using MTA at $MTA_HOME
@@ -189,11 +220,15 @@ if [ ! -x "$JAVACMD" ] ; then
   exit 1
 fi
 
+MODULES=""
 JAVAVER=`"$JAVACMD" -version 2>&1`
 case $JAVAVER in
-*1.[8-9]*) ;;
-*1.[1-7]*)
-	echo " Error: a Java 1.8 or higher JRE is required to run MTA; found [$JAVACMD -version == $JAVAVER]."
+*"11"*)
+    MODULES="--add-modules=java.se"
+    echo "TECH PREVIEW Running on JDK $JAVAVER"
+;;
+*1.[1-9]*)
+	echo " Error: a Java 11 or higher JRE is required to run MTA; found [$JAVACMD -version == $JAVAVER]."
 	exit 1
  ;;
 esac
@@ -238,7 +273,13 @@ fi
 
 MTA_OPTS="$MTA_OPTS $FILE_DESCRIPTOR_OPTS";
 
+if [ "$RUN_OPENREWRITE" != "" ] ; then
+	( cd "$TRANSFORM_PROJECT_PATH"; exec mvn org.openrewrite.maven:rewrite-maven-plugin:4.13.0:"${OPENREWRITE_GOAL}" -DconfigLocation="${MTA_HOME}"/rules/openrewrite/rewrite.yml "${OPENREWRITE_QUOTED_ARGS[@]}" )
+	exit 0;
+
+fi
+
 JAVA_TOOL_OPTIONS=""
 
-$JAVACMD "${MTA_DEBUG_ARGS[@]}" $MTA_OPTS -Dforge.standalone=true -Dforge.home=${MTA_HOME} -Dwindup.home=${MTA_HOME} \
-   -cp ${MTA_HOME}/lib/'*' $MTA_MAIN_CLASS "${QUOTED_ARGS[@]}" "${ADDONS_DIR[@]}"
+exec "$JAVACMD" $MODULES "${MTA_DEBUG_ARGS[@]}" $MTA_OPTS -Dforge.standalone=true -Dforge.home="${MTA_HOME}" -Dwindup.home="${MTA_HOME}" \
+   -cp "${MTA_HOME}"/lib/'*' $MTA_MAIN_CLASS "${QUOTED_ARGS[@]}" "${ADDONS_DIR[@]}"

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -37,7 +37,7 @@
                         <image>
                             <name>${docker.name.windup.web}</name>
                             <build>
-                                <from>registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.0-13</from>
+                                <from>registry.redhat.io/jboss-eap-7/eap73-openjdk11-openshift-rhel8:7.3.10</from>
                                 <cmd>/opt/eap/bin/webapp-launch.sh</cmd>
                                 <assembly>
                                     <targetDir>/</targetDir>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -37,7 +37,7 @@
                         <image>
                             <name>${docker.name.windup.web}</name>
                             <build>
-                                <from>registry.redhat.io/jboss-eap-7/eap73-openjdk11-openshift-rhel8:7.3.10</from>
+                                <from>registry.redhat.io/jboss-eap-7/eap73-openjdk11-openshift-rhel8:7.3.0</from>
                                 <cmd>/opt/eap/bin/webapp-launch.sh</cmd>
                                 <assembly>
                                     <targetDir>/</targetDir>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3269

Changes:
- Change the base container image of the CLI container image to use a base image that provides JDK11. This change will make the container `quay.io/windupeng/windup-cli-openshift:latest` work
- Enhance the script that validates which JDK version is being used for executing Windup. Only JDK 11 is acceptable, any other version should not allow Windup to start.
- Change the container base image of Windup Web to use a base image that provides JDK11. The current base image (the one in master branch) provides JDK 8 which doesn't allow Windup Web to start since we can not execute code that was compiled with JDK 11 and run it with JDK 8