### PR TITLE
[WINDUP-3429] - (Fix) unsecure-deployments.cli and secure-deployments.cli scripts location

### DIFF
--- a/web/src/main/resources/scripts/inject.sh
+++ b/web/src/main/resources/scripts/inject.sh
@@ -17,10 +17,10 @@ ${JBOSS_HOME}/bin/jboss-cli.sh --echo-command --file=${JBOSS_HOME}/utils/configu
 
 if [[ -z "${SSO_AUTH_SERVER_URL}" ]]; then
   echo "Running unsecure-deployments : unsecure-deployments.cli"
-  ${JBOSS_HOME}/bin/jboss-cli.sh --echo-command --file=${JBOSS_HOME}/standalone/configuration/unsecure-deployments.cli
+  ${JBOSS_HOME}/bin/jboss-cli.sh --echo-command --file=${JBOSS_HOME}/utils/configuration/unsecure-deployments.cli
 else
   echo "Running secure-deployments : secure-deployments.cli"
-  ${JBOSS_HOME}/bin/jboss-cli.sh --echo-command --file=${JBOSS_HOME}/standalone/configuration/secure-deployments.cli
+  ${JBOSS_HOME}/bin/jboss-cli.sh --echo-command --file=${JBOSS_HOME}/utils/configuration/secure-deployments.cli
 fi
 
 echo "Setting up JMS Password"


### PR DESCRIPTION
The scripts `unsecure-deployments.cli` and `secure-deployments.cli` are referenced from a wrong location .

To verify the real location of any file we can execute `mvn clean install` and then verifiy the target folder:
![Screenshot from 2022-08-22 15-05-24](https://user-images.githubusercontent.com/2582866/185928310-b7c326b9-77a1-477e-a72c-f5369657d729.png)
