### PR TITLE
Remove no longer used Keycloak folders from assembly fileSets

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -78,10 +78,6 @@
                                                     <outputDirectory>tools</outputDirectory>
                                                 </fileSet>
                                                 <fileSet>
-                                                    <directory>${project.build.directory}/classes/sso/</directory>
-                                                    <outputDirectory>kc-configuration/</outputDirectory>
-                                                </fileSet>
-                                                <fileSet>
                                                     <directory>${project.build.directory}/classes/root-redirect</directory>
                                                     <outputDirectory>root-redirect/</outputDirectory>
                                                 </fileSet>

--- a/web/src/main/resources/scripts/webapp-launch.sh
+++ b/web/src/main/resources/scripts/webapp-launch.sh
@@ -6,7 +6,6 @@ cd $DIR
 export JAVA_OPTS="$JAVA_OPTS -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=512m"
 export JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=org.jboss.byteman"
 export JAVA_OPTS="$JAVA_OPTS -Djboss.modules.settings.xml.url=file://$GALLEON_MAVEN_SETTINGS_XML"
-export JAVA_OPTS="$JAVA_OPTS -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.file=${JBOSS_HOME}/kc-configuration/import-realm.json -Dkeycloak.migration.strategy=IGNORE_EXISTING"
 
 export MAVEN_SETTINGS_PATH="$GALLEON_MAVEN_SETTINGS_XML"
 


### PR DESCRIPTION
- Remove keycloak old folder from `<fileSets>`
- Remove Keycloak old params for importing realm
