### PR TITLE
WINDUP-3762 Fixed CLI container permissions

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -61,6 +61,8 @@
                                                 <fileSet>
                                                     <directory>${project.build.directory}/windup-cli/${product-name}-cli-${version.windup.cli}/</directory>
                                                     <outputDirectory>migrationtoolkit/</outputDirectory>
+                                                    <directoryMode>0774</directoryMode>
+                                                    <fileMode>0774</fileMode>
                                                 </fileSet>
                                             </fileSets>
                                         </layer>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3762

To test the issue run
```sh
$ podman run --rm quay.io/windupeng/windup-cli-openshift:latest
/bin/sh: /opt/migrationtoolkit/bin/windup-cli: Permission denied
```

Pull the PR locally, build the CLI running:
```sh
$ mvn clean install -DskipTests -f cli/
```
and then run the same test above using the locally available `windup-cli-openshift:6.2.0-SNAPSHOT` image to verify the output of the CLI help is printed