### PR TITLE
WINDUP-3763 Added 'multi-arch' profile to multi-arch CLI container build

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ So sign up yourself to Quay.io at https://quay.io/signin/ taking care that the Q
 6. Paste that command in a shell window on your local machine and execute it
 7. Now your local Docker installation will have the credentials in ~/.docker/config.json
 
-### Create Docker images
+### Create Container images
 1. Build this project: `$ mvn clean install -Ddocker.name.windup.web=<your_quay_id>/windup-web-openshift -Ddocker.name.windup.web.executor=<your_quay_id>/windup-web-openshift-messaging-executor`
 1. Push images to docker hub:
    1. `$ docker login`
@@ -39,6 +39,13 @@ So sign up yourself to Quay.io at https://quay.io/signin/ taking care that the Q
    1. `$ docker push <your_quay_id>/windup-web-openshift-messaging-executor`
 
 If you want you can also set the tag for the built images (e.g. if you are working on a specific branch and you want to create images tagged with the branch name), you just have to add the tag name to the `docker.name.windup.web` and `docker.name.windup.web.executor` system properties' values (i.e. from the above example `-Ddocker.name.windup.web=<your_quay_id>/windup-web-openshift:tag_value -Ddocker.name.windup.web.executor=<your_quay_id>/windup-web-openshift-messaging-executor:tag_value`)
+
+### Create CLI multi-arch container image
+1. Login to Quay.io container repository executing  
+`$ docker login quay.io`
+1. Build the CLI multi-arch container and push it to Quay repository  
+`$ mvn clean install -DskipTests -f cli/ -Dmulti-arch -Ddocker.name.windup.cli=quay.io/<your_quay_id>/windup-cli-openshift`
+
 
 ### Point to your images
 Now that your images are available on Quay.io repository, you have to reference them in WINDUP template in order to use these images in the deployments.

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -92,7 +92,9 @@
                                     <name>${docker.name.windup.cli}</name>
                                     <build>
                                         <from>${from.image}</from>
-                                        <cmd>${entrypoint}</cmd>
+                                        <entryPoint>
+                                            <shell>${entrypoint}</shell>
+                                        </entryPoint>
                                         <assembly>
                                             <targetDir>${targetDir}</targetDir>
                                             <exportTargetDir>false</exportTargetDir>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -11,6 +11,11 @@
 
     <properties>
         <docker.name.windup.cli>%a:%v</docker.name.windup.cli>
+        <from.image>registry.access.redhat.com/ubi8/openjdk-11:latest</from.image>
+        <entrypoint>/opt/migrationtoolkit/bin/windup-cli</entrypoint>
+        <targetDir>/opt</targetDir>
+        <outputDirectory>migrationtoolkit/</outputDirectory>
+        <permission>774</permission>
     </properties>
 
     <dependencyManagement>
@@ -27,52 +32,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.eclipse.jkube</groupId>
-                <artifactId>kubernetes-maven-plugin</artifactId>
-                <version>${version.jkube}</version>
-                <executions>
-                    <execution>
-                        <id>jkube</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <buildStrategy>docker</buildStrategy>
-                    <autoPull>always</autoPull>
-                    <images>
-                        <image>
-                            <name>${docker.name.windup.cli}</name>
-                            <build>
-                                <from>registry.access.redhat.com/ubi8/openjdk-11:latest</from>
-                                <cmd>/opt/migrationtoolkit/bin/windup-cli</cmd>
-                                <assembly>
-                                    <targetDir>/opt</targetDir>
-                                    <exportTargetDir>false</exportTargetDir>
-                                    <excludeFinalOutputArtifact>true</excludeFinalOutputArtifact>
-                                    <permissions>keep</permissions>
-                                    <mode>tgz</mode>
-                                    <layers>
-                                        <layer>
-                                            <fileSets>
-                                                <fileSet>
-                                                    <directory>${project.build.directory}/windup-cli/${product-name}-cli-${version.windup.cli}/</directory>
-                                                    <outputDirectory>migrationtoolkit/</outputDirectory>
-                                                    <directoryMode>0774</directoryMode>
-                                                    <fileMode>0774</fileMode>
-                                                </fileSet>
-                                            </fileSets>
-                                        </layer>
-                                    </layers>
-                                </assembly>
-                            </build>
-                        </image>
-                    </images>
-                </configuration>
-            </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
@@ -100,4 +59,160 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!multi-arch</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.jkube</groupId>
+                        <artifactId>kubernetes-maven-plugin</artifactId>
+                        <version>${version.jkube}</version>
+                        <executions>
+                            <execution>
+                                <id>jkube</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <buildStrategy>docker</buildStrategy>
+                            <autoPull>always</autoPull>
+                            <images>
+                                <image>
+                                    <name>${docker.name.windup.cli}</name>
+                                    <build>
+                                        <from>${from.image}</from>
+                                        <cmd>${entrypoint}</cmd>
+                                        <assembly>
+                                            <targetDir>${targetDir}</targetDir>
+                                            <exportTargetDir>false</exportTargetDir>
+                                            <excludeFinalOutputArtifact>true</excludeFinalOutputArtifact>
+                                            <permissions>keep</permissions>
+                                            <mode>tgz</mode>
+                                            <layers>
+                                                <layer>
+                                                    <fileSets>
+                                                        <fileSet>
+                                                            <directory>${project.build.directory}/windup-cli/${product-name}-cli-${version.windup.cli}/</directory>
+                                                            <outputDirectory>${outputDirectory}</outputDirectory>
+                                                            <directoryMode>0${permission}</directoryMode>
+                                                            <fileMode>0${permission}</fileMode>
+                                                        </fileSet>
+                                                    </fileSets>
+                                                </layer>
+                                            </layers>
+                                        </assembly>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>multi-arch</id>
+            <activation>
+                <property>
+                    <name>multi-arch</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-empty-directory</id>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <tasks>
+                                        <!--
+                                        The project has no 'src' folder so no 'target/classes' folder
+                                        will be created along the build process BUT the above jib-maven-plugin
+                                        always searches for classes in the 'target/classes' folder and
+                                        when not found it blocks with an error.
+                                        That's why there's this task for creating such empty folder.
+                                         -->
+                                        <mkdir dir="${project.build.outputDirectory}"/>
+                                    </tasks>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <configuration>
+                                    <containerizingMode>packaged</containerizingMode>
+                                    <from>
+                                        <image>${from.image}</image>
+                                    <platforms>
+                                        <platform>
+                                            <architecture>amd64</architecture>
+                                            <os>linux</os>
+                                        </platform>
+                                        <platform>
+                                            <architecture>arm64</architecture>
+                                            <os>linux</os>
+                                        </platform>
+                                        <platform>
+                                            <architecture>ppc64le</architecture>
+                                            <os>linux</os>
+                                        </platform>
+                                            <platform>
+                                            <architecture>s390x</architecture>
+                                        <os>linux</os>
+                                        </platform>
+                                    </platforms>
+                                    </from>
+                                        <to>
+                                            <image>${docker.name.windup.cli}</image>
+                                        </to>
+                                    <container>
+                                        <entrypoint>${entrypoint}</entrypoint>
+                                    </container>
+                                    <extraDirectories>
+                                        <paths>
+                                            <path>
+                                                <from>${project.build.directory}/windup-cli/${product-name}-cli-${version.windup.cli}/</from>
+                                                <into>${targetDir}/${outputDirectory}</into>
+                                            </path>
+                                        </paths>
+                                        <permissions>
+                                            <permission>
+                                                <file>${targetDir}/${outputDirectory}**</file>
+                                                <mode>${permission}</mode>
+                                            </permission>
+                                        </permissions>
+                                    </extraDirectories>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3763

The idea is to have the Windup CLI container (not the other containers) built for multiple architecture so that the Windup CLI can be easily consumed leveraging docker/podman.

The changes are meant to "not change anything" meaning:

- the `default` profile (enabled by default) keeps running the JKube `kubernetes-maven-plugin` so that a local CLI container image is created and pushed to local to local Docker daemon/Podman service. No changes to any command are required for running this (i.e. `mvn clean install` will work as before)
- the `multi-arch` profile, when enabled (i.e. providing `-Dmulti-arch` option) with disable the `default` profile and enable the `jib-maven-plugin` run a [JIB](https://github.com/GoogleContainerTools/jib) container build.
The multi-arch build has some limitations (ref. [How do I specify a platform in the manifest list (or OCI index) of a base image?](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#how-do-i-specify-a-platform-in-the-manifest-list-or-oci-index-of-a-base-image)): the main one for us is that the images must be pushed to a remote registry because this kind of build "`Does not support pushing to a Docker daemon [...] or building a local tarball`"
- the values (already used) for previously configuring the JKube `kubernetes-maven-plugin` have been moved to be properties so that they have been used also for the `jib-maven-plugin` configuration hence zeroing the maintenance overhead in having 2 plugins

Using the `jib-maven-plugin` is the only viable option because:

- JKube `kubernetes-maven-plugin` doesn't support yet multi-arch builds (ref. [Support for \<buildx\>](https://github.com/eclipse/jkube/issues/1876) and [Support for multiple platforms in jib build strategy](https://github.com/eclipse/jkube/issues/2098) issues)
- Fabric8 `docker-maven-plugin` supports [Multi-Architecture Build](https://dmp.fabric8.io/#build-buildx) but, since docker and podman are *not* consistent in the `buildx` feature for running multi-arch builds, adopting this plugin would have dropped support for podman in this project and it wasn't a suitable option


Testing

1. `mvn clean install -DskipTests` will prove everything works as before
2. `mvn clean install -DskipTests -f cli/ -Dmulti-arch -Ddocker.name.windup.cli=quay.io/<your_quay_id>/windup-cli-openshift` will let you test the multi-arch build worked (keep in mind this, as described above, will push the images to the `<your_quay_id>` account, so `podman login quay.io` must be executed in other to be authorized to push).
An example of such a build is available at https://quay.io/repository/mrizzi/windup-cli-openshift?tab=tags