### PR TITLE
[WINDUP-3915] - windup-openshift project: add daily container CLI tests

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,4 +1,4 @@
-name: Snapshots
+name: CLI Container image check
 
 on:
   schedule:
@@ -21,16 +21,7 @@ jobs:
         run: |
           brew install docker
           colima start
-#      - name: Setup podman (missing on MacOS)
-#        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'podman' }}
-#        run: |
-#          brew install podman
-#          podman machine init --now
-#      - name: Setup podman (missing on Windows)
-#        if: ${{ matrix.os == 'windows-latest' && matrix.runtime == 'podman' }}
-#        run: |
-#          brew install podman
-#          podman machine init --now
+
       - name: Container runtime info
         run: |
           ${{ matrix.runtime }} run --name windup-cli --pull always quay.io/windupeng/windup-cli-openshift:latest --input /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear --output /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear.report --target discovery --exportZipReport

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -33,7 +33,7 @@ jobs:
 #          podman machine init --now
       - name: Container runtime info
         run: |
-          ${{ matrix.runtime }} run --name windup-cli --pull newer \
+          ${{ matrix.runtime }} run --name windup-cli --pull always \
           quay.io/windupeng/windup-cli-openshift:latest \
           --input /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear \
           --output /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear.report \

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -28,12 +28,21 @@ jobs:
           podman machine init
           podman machine start
 
-      - name: Container runtime info
+      - name: Windup analysis
         run: |
           ${{ matrix.runtime }} run --name windup-cli --pull always quay.io/windupeng/windup-cli-openshift:latest --input /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear --output /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear.report --target discovery --exportZipReport
           
           # Extract report
           ${{ matrix.runtime }} cp windup-cli:/opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear.report/reports.zip .
 
-          # 
+          # Extract reports
           unzip reports.zip -d reports
+      - name: Verify reports
+        run: |
+          if [ -e reports/index.html ]
+          then
+            echo "index.html exists"
+          else
+            echo "could not find index.html"
+            exit 1
+          fi

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         runtime: [ docker, podman ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -25,8 +25,8 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'podman' }}
         run: |
           brew install podman
+          podman machine init
           podman machine start
-          podman machine init --now
 
       - name: Container runtime info
         run: |

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        runtime: [ docker ]
+        runtime: [ docker, podman ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup docker (missing on MacOS)
@@ -21,6 +21,12 @@ jobs:
         run: |
           brew install docker
           colima start
+      - name: Setup podman (missing on MacOS)
+        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'podman' }}
+        run: |
+          brew install podman
+          podman machine start
+          podman machine init --now
 
       - name: Container runtime info
         run: |

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -27,7 +27,7 @@ jobs:
           brew install podman
           podman machine init --now
       - name: Setup podman (missing on Windows)
-        if: ${{ matrix.os == 'window-latest' && matrix.runtime == 'podman' }}
+        if: ${{ matrix.os == 'windows-latest' && matrix.runtime == 'podman' }}
         run: |
           brew install podman
           podman machine init --now

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           brew install docker
       - name: Setup podman (missing on MacOS)
-        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'docker' }}
+        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'podman' }}
         run: |
           brew install podman
       - name: Maven

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        runtime: [ docker, podman ]
+        runtime: [ docker ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup docker (missing on MacOS)
@@ -21,19 +21,27 @@ jobs:
         run: |
           brew install docker
           colima start
-      - name: Setup podman (missing on MacOS)
-        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'podman' }}
-        run: |
-          brew install podman
-          podman machine init --now
-      - name: Setup podman (missing on Windows)
-        if: ${{ matrix.os == 'windows-latest' && matrix.runtime == 'podman' }}
-        run: |
-          brew install podman
-          podman machine init --now
+#      - name: Setup podman (missing on MacOS)
+#        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'podman' }}
+#        run: |
+#          brew install podman
+#          podman machine init --now
+#      - name: Setup podman (missing on Windows)
+#        if: ${{ matrix.os == 'windows-latest' && matrix.runtime == 'podman' }}
+#        run: |
+#          brew install podman
+#          podman machine init --now
       - name: Container runtime info
         run: |
-          ${{ matrix.runtime }} version
-      - name: Container test
-        run: |
-          ${{ matrix.runtime }} run quay.io/podman/hello
+          ${{ matrix.runtime }} run --name windup-cli --pull newer \
+          quay.io/windupeng/windup-cli-openshift:latest
+          --input /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear \
+          --output /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear.report \
+          --target discovery \
+          --exportZipReport
+          
+          # Extract report
+          ${{ matrix.runtime }} cp windup-cli:/opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear.report/reports.zip .
+
+          # 
+          unzip reports.zip -d reports

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Container runtime info
         run: |
           ${{ matrix.runtime }} run --name windup-cli --pull newer \
-          quay.io/windupeng/windup-cli-openshift:latest
+          quay.io/windupeng/windup-cli-openshift:latest \
           --input /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear \
           --output /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear.report \
           --target discovery \

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -20,9 +20,12 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'docker' }}
         run: |
           brew install docker
+          colima start
       - name: Setup podman (missing on MacOS)
         if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'podman' }}
         run: |
           brew install podman
+          podman machine init
+          podman machine start
       - name: Maven
         run: ${{ matrix.runtime }} version

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -12,9 +12,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runtime: [ docker, podman ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
+        runtime: [ docker, podman ]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Setup docker (missing on MacOS)
+        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'docker' }}
+        run: |
+          brew install docker
+      - name: Setup podman (missing on MacOS)
+        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'docker' }}
+        run: |
+          brew install podman
       - name: Maven
         run: ${{ matrix.runtime }} version

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,6 +16,7 @@ jobs:
         runtime: [ docker, podman ]
     runs-on: ${{ matrix.os }}
     steps:
+      - run: exit 1
       - name: Setup docker (missing on MacOS)
         if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'docker' }}
         run: |
@@ -38,7 +39,7 @@ jobs:
           # Extract reports
           unzip reports.zip -d reports
       - name: Verify reports
-        run: |
+        run: |          
           if [ -e reports/index.html ]
           then
             echo "index.html exists"

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -33,12 +33,7 @@ jobs:
 #          podman machine init --now
       - name: Container runtime info
         run: |
-          ${{ matrix.runtime }} run --name windup-cli --pull always \
-          quay.io/windupeng/windup-cli-openshift:latest \
-          --input /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear \
-          --output /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear.report \
-          --target discovery \
-          --exportZipReport
+          ${{ matrix.runtime }} run --name windup-cli --pull always quay.io/windupeng/windup-cli-openshift:latest --input /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear --output /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear.report --target discovery --exportZipReport
           
           # Extract report
           ${{ matrix.runtime }} cp windup-cli:/opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear.report/reports.zip .

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container-runtime: [ docker, podman ]
+        runtime: [ docker, podman ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Maven
-        run: ${{ matrix.os }} version
+        run: ${{ matrix.runtime }} version

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,16 +16,31 @@ jobs:
         runtime: [ docker, podman ]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup docker (missing on MacOS)
-        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'docker' }}
-        run: |
-          brew install docker
-          colima start
-      - name: Setup podman (missing on MacOS)
-        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'podman' }}
-        run: |
-          brew install podman
-          podman machine init
-          podman machine start
+      - name: Login to ghcr.io (Docker)
+        if: ${{ matrix.runtime == 'docker' }}
+        uses: docker/login-action@v2
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+      - name: Log in to ghcr.io (Podman)
+        if: ${{ matrix.runtime == 'podman' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+
+#      - name: Setup docker (missing on MacOS)
+#        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'docker' }}
+#        run: |
+#          brew install docker
+#          colima start
+#      - name: Setup podman (missing on MacOS)
+#        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'podman' }}
+#        run: |
+#          brew install podman
+#          podman machine init
+#          podman machine start
       - name: Maven
         run: ${{ matrix.runtime }} version

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,20 @@
+name: Snapshots
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs: { }
+
+jobs:
+  tests:
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        container-runtime: [ docker, podman ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Maven
+        run: ${{ matrix.os }} version

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,31 +16,24 @@ jobs:
         runtime: [ docker, podman ]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Login to ghcr.io (Docker)
-        if: ${{ matrix.runtime == 'docker' }}
-        uses: docker/login-action@v2
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-      - name: Log in to ghcr.io (Podman)
-        if: ${{ matrix.runtime == 'podman' }}
-        uses: redhat-actions/podman-login@v1
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-
-#      - name: Setup docker (missing on MacOS)
-#        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'docker' }}
-#        run: |
-#          brew install docker
-#          colima start
-#      - name: Setup podman (missing on MacOS)
-#        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'podman' }}
-#        run: |
-#          brew install podman
-#          podman machine init
-#          podman machine start
-      - name: Maven
-        run: ${{ matrix.runtime }} version
+      - name: Setup docker (missing on MacOS)
+        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'docker' }}
+        run: |
+          brew install docker
+          colima start
+      - name: Setup podman (missing on MacOS)
+        if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'podman' }}
+        run: |
+          brew install podman
+          podman machine init --now
+      - name: Setup podman (missing on Windows)
+        if: ${{ matrix.os == 'window-latest' && matrix.runtime == 'podman' }}
+        run: |
+          brew install podman
+          podman machine init --now
+      - name: Container runtime info
+        run: |
+          ${{ matrix.runtime }} version
+      - name: Container test
+        run: |
+          ${{ matrix.runtime }} run quay.io/podman/hello

--- a/.github/workflows/windup_cli_openshift_cron.yml
+++ b/.github/workflows/windup_cli_openshift_cron.yml
@@ -16,6 +16,9 @@ jobs:
         runtime: [ docker, podman ]
     runs-on: ${{ matrix.os }}
     steps:
+      - run: uname -m
+      - run: uname -p
+      - run: uname -m
       - name: Setup docker (missing on MacOS)
         if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'docker' }}
         run: |

--- a/.github/workflows/windup_cli_openshift_cron.yml
+++ b/.github/workflows/windup_cli_openshift_cron.yml
@@ -16,9 +16,6 @@ jobs:
         runtime: [ docker, podman ]
     runs-on: ${{ matrix.os }}
     steps:
-      - run: uname -m
-      - run: uname -p
-      - run: uname -m
       - name: Setup docker (missing on MacOS)
         if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'docker' }}
         run: |

--- a/.github/workflows/windup_cli_openshift_cron.yml
+++ b/.github/workflows/windup_cli_openshift_cron.yml
@@ -1,4 +1,4 @@
-name: CLI Container image check
+name: Windup CLI Container Cron Check
 
 on:
   schedule:
@@ -16,7 +16,6 @@ jobs:
         runtime: [ docker, podman ]
     runs-on: ${{ matrix.os }}
     steps:
-      - run: exit 1
       - name: Setup docker (missing on MacOS)
         if: ${{ matrix.os == 'macos-latest' && matrix.runtime == 'docker' }}
         run: |
@@ -31,15 +30,16 @@ jobs:
 
       - name: Windup analysis
         run: |
+          # Execute analysis
           ${{ matrix.runtime }} run --name windup-cli --pull always quay.io/windupeng/windup-cli-openshift:latest --input /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear --output /opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear.report --target discovery --exportZipReport
           
-          # Extract report
+          # Extract report from container
           ${{ matrix.runtime }} cp windup-cli:/opt/migrationtoolkit/samples/jee-example-app-1.0.0.ear.report/reports.zip .
 
-          # Extract reports
+          # Unzip reports
           unzip reports.zip -d reports
       - name: Verify reports
-        run: |          
+        run: |
           if [ -e reports/index.html ]
           then
             echo "index.html exists"


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3915

- Adding a daily test using Podman|Docker on Ubuntu and MacOS.
- Windows OS is excluded due to the fact that Windup CLI container image was not being able to be executed. Here is the details of the error

```
docker: no matching manifest for windows/amd64 10.0.20348 in the manifest list entries
```