### PR TITLE
Temporary disable CLI container build

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -63,12 +63,12 @@
     <profiles>
         <profile>
             <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-                <property>
-                    <name>!multi-arch</name>
-                </property>
-            </activation>
+<!--            <activation>-->
+<!--                <activeByDefault>true</activeByDefault>-->
+<!--                <property>-->
+<!--                    <name>!multi-arch</name>-->
+<!--                </property>-->
+<!--            </activation>-->
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
Trying to avoid the CLI container useless build that fails (e.g. https://github.com/windup/windup-pipelines/actions/runs/6508968908/job/17686649163#step:12:10133)